### PR TITLE
Check if user exceeded the 100h limit and other things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ virt/
 remaining_downloads.json
 twitch_highlights.json
 srcom_cached/
+output/
+twitch_cache.json
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cython_debug/
 virt/
 remaining_downloads.json
 twitch_highlights.json
+srcom_cached/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests~=2.32.3
 yt-dlp~=2025.2.19
 isodate~=0.7.2
+twitchAPI~=4.4.0

--- a/speedrunrescue.py
+++ b/speedrunrescue.py
@@ -79,7 +79,7 @@ def get_all_runs_from_game(game_id):
 
     return runs
 
-twitch_url_regex = re.compile(r"(https?:\/\/)?(?:www\.)?twitch\.tv\/\S*", re.IGNORECASE)
+twitch_url_regex = re.compile(r"(https?:\/\/)?(?:www\.)?(?:m.)?(?:secure\.)?twitch\.tv\/\S*", re.IGNORECASE)
 def is_twitch_url(url):
     # Checking with regex if its a twitch highlight
     return twitch_url_regex.search(url)
@@ -156,6 +156,7 @@ def format_date_of_submission(dateobj):
 
 def save_highlights(highlights, client, highlights_filename, remaining_downloads_filename, highlights_json_filename):
     #saving all highlights in a formatted way for the user i guess? My hope is I can automate uploads later
+    num_at_risk = 0
     
     for highlight in highlights:
         new_twitch_urls = []
@@ -168,7 +169,11 @@ def save_highlights(highlights, client, highlights_filename, remaining_downloads
                 new_twitch_urls.append(twitch_url)
         highlight["urls"] = new_twitch_urls
         highlight["at_risk"] = at_risk
-    
+        if at_risk:
+            num_at_risk += 1
+
+    print(f"Number of at-risk runs: {num_at_risk}")
+
     with open(highlights_filename, "w", encoding="utf-8") as f:
         for entry in highlights:
             #formatting the iso format

--- a/speedrunrescue.py
+++ b/speedrunrescue.py
@@ -7,6 +7,9 @@ import yt_dlp
 import json
 from datetime import datetime
 import srcomapi
+import twitch_integration
+import asyncio
+import pathlib
 
 # Configuration
 BASE_URL = "https://www.speedrun.com/api/v1"
@@ -89,9 +92,10 @@ def filter_live(info):
     # Otherwise, return None to allow the video.
     return None
 
-def process_runs(runs):
+async def process_runs(runs, client):
     #Extract Twitch highlight urls from runs
     highlights = []
+    all_twitch_urls = []
     for run in runs:
         videos = run.get('videos') or {}
         links = videos.get('links') or []
@@ -132,10 +136,14 @@ def process_runs(runs):
                 'comment': run.get('comment', '')
             }
 
+            all_twitch_urls.extend(twitch_urls)
             if len(player_twitch_yt_urls) != 0:
                 highlight["vod_sites"] = player_twitch_yt_urls
 
             highlights.append(highlight)
+
+    await client.fetch_info(all_twitch_urls)
+    client.write_twitch_users_at_risk()
 
     return highlights
 
@@ -146,9 +154,22 @@ def format_date_of_submission(dateobj):
         formatted_date = "Unknown date"
     return formatted_date
 
-def save_highlights(highlights):
+def save_highlights(highlights, client, highlights_filename, remaining_downloads_filename, highlights_json_filename):
     #saving all highlights in a formatted way for the user i guess? My hope is I can automate uploads later
-    with open(HIGHLIGHTS_FILE, "w", encoding="utf-8") as f:
+    
+    for highlight in highlights:
+        new_twitch_urls = []
+        at_risk = False
+        for twitch_url in highlight["urls"]:
+            if client.is_video_at_risk(twitch_url):
+                at_risk = True
+                new_twitch_urls.append(f"{twitch_url}*****")
+            else:
+                new_twitch_urls.append(twitch_url)
+        highlight["urls"] = new_twitch_urls
+        highlight["at_risk"] = at_risk
+    
+    with open(highlights_filename, "w", encoding="utf-8") as f:
         for entry in highlights:
             #formatting the iso format
 
@@ -159,6 +180,7 @@ def save_highlights(highlights):
             f.write(f"Run Date: {format_date_of_submission(entry['date'])}\n")
             f.write(f"URL: {' '.join(entry['urls'])}\n")
             f.write(f"Run ID: {entry['run_id']}\n")
+            f.write(f"Channel exceeds 100h limit: {entry['at_risk']}\n")
             f.write(f"Comment: {entry['comment']}\n")
             vod_sites = entry.get("vod_sites")
             if vod_sites is not None:
@@ -167,13 +189,12 @@ def save_highlights(highlights):
             f.write("-" * 50 + "\n")
 
     urls = [url for entry in highlights for url in entry["urls"]]
-    with open("remaining_downloads.json", "w", encoding="utf-8") as f:
+    with open(remaining_downloads_filename, "w", encoding="utf-8") as f:
         json.dump(urls, f, indent=4)
-    with open(HIGHLIGHTS_JSON, "w", encoding="utf-8") as f:
+    with open(highlights_json_filename, "w", encoding="utf-8") as f:
         json.dump(highlights, f, indent=4)
 
-
-def download_videos():
+def download_videos(remaining_downloads_filename):
     #downloading videos out of the provided dict using the yt-dlp module.
     ydl_options = {
         'format': 'bestvideo+bestaudio/best',
@@ -188,7 +209,7 @@ def download_videos():
     while True:
         try:
             # Load URLs from JSON file
-            with open("remaining_downloads.json", "r", encoding="utf-8") as f:
+            with open(remaining_downloads_filename, "r", encoding="utf-8") as f:
                 urls = json.load(f)
 
             # Stop if no URLs are left
@@ -205,7 +226,7 @@ def download_videos():
                 except yt_dlp.utils.DownloadError as e:
                     print(f"Skipping invalid or dead link: {first_url} - Error: {e}")
                     urls.pop(0)
-                    with open("remaining_downloads.json", "w", encoding="utf-8") as f:
+                    with open(remaining_downloads_filename, "w", encoding="utf-8") as f:
                         json.dump(urls, f, indent=4)
                     continue
 
@@ -215,13 +236,13 @@ def download_videos():
                         print(f"Error: {e}")
                         print("There is a rate limit or some other access restriction (403 Forbidden).")
                         if input("Do you want to stop and resume later? \nYour progress so far has been stored in the remaining_downloads.json (y/n): ").strip().lower().startswith("y"):
-                            with open("remaining_downloads.json", "w", encoding="utf-8") as f:
+                            with open(remaining_downloads_filename, "w", encoding="utf-8") as f:
                                 json.dump(urls, f, indent=4)
                             print("Progress saved. You can resume the download later.")
                             return  # Exit the function and resume later
 
                 urls.pop(0)
-                with open("remaining_downloads.json", "w", encoding="utf-8") as f:
+                with open(remaining_downloads_filename, "w", encoding="utf-8") as f:
                     json.dump(urls, f, indent=4)
 
         except FileNotFoundError:
@@ -236,9 +257,9 @@ def download_videos():
         except Exception as e:
             print(f"Unexpected error: {e}")
 
-def load_remaining_downloads():
+def load_remaining_downloads(remaining_downloads_filename):
     try:
-        with open("remaining_downloads.json", "r", encoding="utf-8") as f:
+        with open(remaining_downloads_filename, "r", encoding="utf-8") as f:
             urls = json.load(f)
         if not urls:
             print("No remaining downloads file found")
@@ -251,23 +272,41 @@ def load_remaining_downloads():
     except Exception as e:
         print(f"Unexpected error: {e}")
 
-def main():
+async def main():
+    pathlib.Path("output").mkdir(exist_ok=True)
+    with open("config.json", "r") as f:
+        config = json.load(f)
+
+    game = config["game"]
+    if game:
+        download_type_str = "game"
+        game_or_username = game
+        is_game = True
+    else:
+        username = config["username"]
+        if not username:
+            raise RuntimeError("Neither username nor game specified!")
+
+        download_type_str = "user"
+        game_or_username = username
+        is_game = False
+
+    highlights_filename = f"output/twitch_highlights.{download_type_str}.{game_or_username}.txt"
+    highlights_json_filename = f"output/twitch_highlights.{download_type_str}.{game_or_username}.json"
+    remaining_downloads_filename = f"output/remaining_downloads.{download_type_str}.{game_or_username}.json"
+
     #Check if there are remaining Downloads left.
-    remaininDownloads = load_remaining_downloads()
+    remaininDownloads = load_remaining_downloads(remaining_downloads_filename)
     if remaininDownloads and input("A remaining downloads file has been found. Do you want to continue the download? (y/n): ").lower().startswith("y"):
-        download_videos()
+        download_videos(config["remaining_downloads_file"])
         return
 
-    if input("Do you want to backup a game? If no, this will default to users (y/n): ").lower().startswith("y"):
-        print("Enter Speedrun.com Game abbreviation.")
-        print("An example, (here in brackets) would be: speedrun.com/[sm64]. The abbreviation would be sm64")
-        game = input("Enter Speedrun.com Game abbreviation: ").strip()
+    if is_game:
         print(f"Searching for {game}...")
         game_id = get_game_id(game)
         print(f"Getting all runs")
         runs = get_all_runs_from_game(game_id)
     else:
-        username = input("Enter Speedrun.com username: ").strip()
         print(f"Searching for {username}...")
         # Getting the user id first from the username.
         user_id = get_user_id(username)
@@ -278,21 +317,23 @@ def main():
         # Fetch all runs from user
         print("Fetching runs...")
         runs = get_all_runs(user_id)
-        print(f"Found {len(runs)} verified runs")
 
+    print(f"Found {len(runs)} verified runs")
+
+    client = await twitch_integration.TwitchClient.init(config)
     # Checking for highlights
-    highlights = process_runs(runs)
+    highlights = await process_runs(runs, client)
     print(f"Found {len(highlights)} Twitch highlights")
 
     # Save highlights
-    save_highlights(highlights)
-    print(f"Saved highlights to {HIGHLIGHTS_FILE}")
+    save_highlights(highlights, client, highlights_filename, remaining_downloads_filename, highlights_json_filename)
+    print(f"Saved highlights to {highlights_filename}")
 
     # Download prompt for users and downloading videos
     if highlights and input("Download videos? (y/n): ").lower().startswith("y"):
-        download_videos()
+        download_videos(remaining_downloads_filename)
         print("Download completed")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/srcomapi.py
+++ b/srcomapi.py
@@ -1,0 +1,96 @@
+import requests
+import urllib
+import pathlib
+import json
+import time
+import re
+
+class CacheSettings:
+    __slots__ = ("read_cache", "write_cache", "cache_dirname", "rate_limit", "retry_on_empty")
+
+    def __init__(self, read_cache, write_cache, cache_dirname, rate_limit):
+        self.read_cache = read_cache
+        self.write_cache = write_cache
+        self.cache_dirname = cache_dirname
+        self.rate_limit = rate_limit
+
+default_cache_settings = CacheSettings(True, True, "srcom_cached", True)
+
+def get_cached_endpoint_filepath(endpoint, params, cache_settings):
+    endpoint_as_pathname = f"{cache_settings.cache_dirname}/{urllib.parse.quote(endpoint, safe='')}_q_{urllib.parse.urlencode(params, doseq=True)}.json"
+
+    return pathlib.Path(endpoint_as_pathname)
+
+API_URL = "https://www.speedrun.com/api/v1"
+
+def get(endpoint, params=None, cache_settings=None, require_success=False):
+    exception_sleep_time = 15
+
+    while True:
+        try:
+            return get_in_loop_code(endpoint, params, cache_settings)[0]
+        except ConnectionError as e:
+            print(f"Exception occurred: {e}\n{''.join(traceback.format_tb(e.__traceback__))}\nSleeping for {exception_sleep_time} seconds now.")
+            time.sleep(exception_sleep_time)
+            exception_sleep_time *= 2
+            if exception_sleep_time > 1000:
+                exception_sleep_time = 1000
+
+def get_in_loop_code(endpoint, params, cache_settings):
+    if params is None:
+        params = {}
+
+    if cache_settings is None:
+        cache_settings = default_cache_settings
+
+    endpoint_as_path = get_cached_endpoint_filepath(endpoint, params, cache_settings)
+    if cache_settings.read_cache and endpoint_as_path.is_file():
+        error_code = None
+
+        endpoint_as_path_size = endpoint_as_path.stat().st_size
+        if endpoint_as_path_size == 0:
+            return {}, 404
+
+        #print(f"endpoint_as_path: {endpoint_as_path}")
+        with open(endpoint_as_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        if error_code is None:
+            return data, 200
+
+    url = f"{API_URL}{endpoint}"
+    print(f"url: {url}?{urllib.parse.urlencode(params, doseq=True)}")
+    start_time = time.time()
+    r = requests.get(url, params=params)
+    end_time = time.time()
+    print(f"Request took {end_time - start_time}.")
+
+    if cache_settings.write_cache:
+        endpoint_as_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if r.status_code != 200:
+        #if r.status_code != 404:
+        #    raise ConnectionError(f"Got status code {r.status_code}!")
+        #
+        #if cache_settings.write_cache:
+        #    if r.status_code == 404:
+        #        endpoint_as_path.touch()
+        #    else:
+        #        print(f"Got non-404 error code: {r.status_code}")
+        #        with open(endpoint_as_path, "w+") as f:
+        #            f.write(str(r.status_code))
+        #
+        #return r.reason, r.status_code
+        raise RuntimeError(f"API returned {r.status_code}: {r.reason}")
+
+    data = r.json()
+
+    if cache_settings.write_cache:
+        endpoint_as_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(endpoint_as_path, "w+", encoding="utf-8") as f:
+            json.dump(data, f, separators=(",", ":"))
+
+    if cache_settings.rate_limit:
+        time.sleep(1)
+
+    return data, r.status_code

--- a/srcomapi.py
+++ b/srcomapi.py
@@ -69,6 +69,11 @@ def get_in_loop_code(endpoint, params, cache_settings):
         endpoint_as_path.parent.mkdir(parents=True, exist_ok=True)
 
     if r.status_code != 200:
+        if r.status_code >= 400 and r.status_code < 500:
+            raise RuntimeError(f"API returned {r.status_code}: {r.reason}")
+
+        raise ConnectionError(f"Got status code {r.status_code}!")
+        #return r.reason, r.status_code
         #if r.status_code != 404:
         #    raise ConnectionError(f"Got status code {r.status_code}!")
         #
@@ -81,7 +86,6 @@ def get_in_loop_code(endpoint, params, cache_settings):
         #            f.write(str(r.status_code))
         #
         #return r.reason, r.status_code
-        raise RuntimeError(f"API returned {r.status_code}: {r.reason}")
 
     data = r.json()
 

--- a/twitch_integration.py
+++ b/twitch_integration.py
@@ -1,0 +1,210 @@
+from twitchAPI.twitch import Twitch
+from twitchAPI.helper import first
+import asyncio
+import json
+import pathlib
+import itertools
+import re
+
+twitch_c_v_url_regex = re.compile(r"(?:https?:\/\/)?(?:www\.)?twitch\.tv\/(\w+)\/([cv])\/(\d+)", re.IGNORECASE)
+twitch_current_url_regex = re.compile(r"(?:https?:\/\/)?(?:www\.)?twitch\.tv\/videos/(\d+)", re.IGNORECASE)
+
+def grouper(iterable, n):
+    it = iter(iterable)
+    while True:
+        chunk = list(itertools.islice(it, n))
+        if not chunk:  # Stop when no more elements are left
+            break
+        yield chunk
+
+duration_regex = re.compile(r"^(?:([0-9]+)h)?(?:([0-9]+)m)?(?:([0-9]+)s?)?$")
+
+def parse_duration(duration):
+    match_obj = duration_regex.match(duration.strip())
+    if match_obj:
+        hours = match_obj.group(1)
+        minutes = match_obj.group(2)
+        seconds = match_obj.group(3)
+        if hours is None and minutes is None and seconds is None:
+            raise RuntimeError(f"Invalid duration \"{expiry_time}\" provided for expiry time!")
+
+        if hours is None:
+            hours = 0
+        if minutes is None:
+            minutes = 0
+        if seconds is None:
+            seconds = 0
+
+        try:
+            duration_as_seconds = int(hours) * 3600 + int(minutes) * 60 + int(seconds)
+        except ValueError:
+            raise RuntimeError(f"At least one of hours, seconds, and minutes not an integer!")
+    else:
+        raise RuntimeError(f"Invalid duration \"{expiry_time}\" provided for expiry time!")
+
+    return duration_as_seconds
+
+class UserCache:
+    __slots__ = ("cache_filename", "cache_info")
+
+    def __init__(self, cache_filename):
+        cache_filepath = pathlib.Path(cache_filename)
+        if cache_filepath.is_file():
+            with open(cache_filename, "r") as f:
+                cache_info = json.load(f)
+        else:
+            cache_info = {
+                "video_infos": {},
+                "user_infos": {},
+                "total_duration": -1
+            }
+
+        self.cache_info = cache_info
+        self.cache_filename = cache_filename
+
+    def parse_valid_video_id(self, video_url, update_c=False):
+        match_obj = twitch_c_v_url_regex.match(video_url)
+        if match_obj:
+            url_type = match_obj.group(2)
+            if url_type == "c":
+                if update_c_ignore_found:
+                    user_info = self.get_user_info(match_obj.group(1))
+                    user_info["c_video_urls"].append(video_url)
+                    print(f"Skipped c-type url {video_url}")
+                video_id = None
+            else:
+                video_id = match_obj.group(3)
+        else:
+            match_obj = twitch_current_url_regex.match(video_url)
+            if match_obj:
+                video_id = match_obj.group(1)
+            else:
+                print(f"Skipped non-video url {video_url}")
+                video_id = None
+
+        return video_id
+
+    async def update_video_infos_from_video_urls(self, twitch, video_urls):
+        valid_nonfound_video_ids = []
+        print("Finding valid video ids!")
+        for video_url in video_urls:
+            video_id = self.parse_valid_video_id(video_url, update_c=True)
+            if video_id is not None:
+                video_info = self.cache_info["video_infos"].get(video_id)
+                if video_info is None:
+                    valid_nonfound_video_ids.append(video_id)
+
+        if len(valid_nonfound_video_ids) != 0:
+            print(f"Fetching video info from {len(valid_nonfound_video_ids)} valid video ids!")
+            for i, valid_nonfound_video_ids_chunk in enumerate(grouper(valid_nonfound_video_ids, 100)):
+                print(f"video_ids_chunk: {valid_nonfound_video_ids_chunk}")
+                print(f"Parsing chunk {100*i}")
+                async for video_info_obj in twitch.get_videos(ids=valid_nonfound_video_ids_chunk, first=100):
+                    video_info = video_info_obj.to_dict()
+                    self.cache_info["video_infos"][video_info["id"]] = video_info
+            
+            valid_nonfound_video_ids_as_set = frozenset(valid_nonfound_video_ids)
+            found_video_info_ids = frozenset(self.cache_info["video_infos"].keys())
+            missing_video_ids = valid_nonfound_video_ids_as_set - found_video_info_ids
+
+            for missing_video_id in missing_video_ids:
+                self.cache_info["video_infos"][missing_video_id] = {"missing": True}
+
+        self.save_cache()
+
+    async def update_user_infos_from_video_infos(self, twitch):
+        for video_id, video_info in self.cache_info["video_infos"].items():
+            if video_info.get("missing"):
+                continue
+
+            username = video_info["user_login"]
+            user_info = self.get_user_info(username)
+            if len(user_info["videos"]) == 0:
+                print(f"Downloading video info for {username}!")
+                user_id = video_info["user_id"]
+                num_video_infos = 0
+                async for user_video_info_obj in twitch.get_videos(user_id=user_id, first=100):
+                    user_video_info = user_video_info_obj.to_dict()
+                    user_info["videos"][user_video_info["id"]] = user_video_info
+                    num_video_infos += 1
+                
+                print(f"num_video_infos: {num_video_infos}")
+                self.save_cache()
+
+    def determine_at_risk_users(self):
+        print(f"Determining at risk users!")
+        for username, user_info in self.cache_info["user_infos"].items():
+            total_duration = 0
+            for video_id, user_video_info in user_info["videos"].items():
+                total_duration += parse_duration(user_video_info["duration"])
+
+            user_info["total_duration"] = total_duration
+
+        self.save_cache()
+
+    def is_video_at_risk(self, video_url):
+        video_id = self.parse_valid_video_id(video_url)
+        if video_id is None:
+            return False
+    
+        video_info = self.cache_info["video_infos"].get(video_id)
+        if video_info is None or video_info.get("missing"):
+            return False
+
+        username = video_info["user_login"]
+        user_info = self.cache_info["user_infos"].get(username)
+        if user_info is None:
+            return False
+
+        if user_info["total_duration"] >= 360000:
+            return True
+        else:
+            return False
+
+    def write_twitch_users_at_risk(self):
+        twitch_users_sorted_by_total_duration = sorted(self.cache_info["user_infos"].items(), key=lambda x: x[1]["total_duration"], reverse=True)
+        output = "".join(f"{username}: {user_info['total_duration']}\n" for username, user_info in twitch_users_sorted_by_total_duration)
+
+        with open("output/twitch_users_sorted_by_total_duration.txt", "w+") as f:
+            f.write(output)
+
+    def get_user_info(self, username):
+        user_info = self.cache_info["user_infos"].get(username)
+        if user_info is None:
+            user_info = {
+                "c_video_urls": [],
+                "videos": {}
+            }
+            self.cache_info["user_infos"][username] = user_info
+        return user_info
+
+    def save_cache(self):
+        with open(self.cache_filename, "w+") as f:
+            json.dump(self.cache_info, f, indent=2)
+
+class TwitchClient:
+    __slots__ = ("config", "twitch", "user_cache")
+
+    def __init__(self, config, twitch):
+        self.config = config
+        self.twitch = twitch
+        self.user_cache = UserCache(self.config["cache_filename"])
+
+    @classmethod
+    async def init(cls, config):
+        app_id = config["app_id"]
+        app_secret = config["app_secret"]
+        twitch = await Twitch(app_id, app_secret)
+
+        return cls(config, twitch)
+
+    async def fetch_info(self, video_urls):
+        await self.user_cache.update_video_infos_from_video_urls(self.twitch, video_urls)
+        await self.user_cache.update_user_infos_from_video_infos(self.twitch)
+        self.user_cache.determine_at_risk_users()
+
+    def is_video_at_risk(self, video_url):
+        return self.user_cache.is_video_at_risk(video_url)    
+
+    def write_twitch_users_at_risk(self):
+        self.user_cache.write_twitch_users_at_risk()

--- a/twitch_integration.py
+++ b/twitch_integration.py
@@ -6,8 +6,8 @@ import pathlib
 import itertools
 import re
 
-twitch_c_v_url_regex = re.compile(r"(?:https?:\/\/)?(?:www\.)?twitch\.tv\/(\w+)\/([cv])\/(\d+)", re.IGNORECASE)
-twitch_current_url_regex = re.compile(r"(?:https?:\/\/)?(?:www\.)?twitch\.tv\/videos/(\d+)", re.IGNORECASE)
+twitch_c_v_url_regex = re.compile(r"(?:https?:\/\/)?(?:www\.)?(?:m.)?(?:secure\.)?twitch\.tv\/(\w+)\/([cv])\/(\d+)", re.IGNORECASE)
+twitch_current_url_regex = re.compile(r"(?:https?:\/\/)?(?:www\.)?(?:m.)?(?:secure\.)?twitch\.tv\/videos/(\d+)", re.IGNORECASE)
 
 def grouper(iterable, n):
     it = iter(iterable)
@@ -67,7 +67,7 @@ class UserCache:
         if match_obj:
             url_type = match_obj.group(2)
             if url_type == "c":
-                if update_c_ignore_found:
+                if update_c:
                     user_info = self.get_user_info(match_obj.group(1))
                     user_info["c_video_urls"].append(video_url)
                     print(f"Skipped c-type url {video_url}")


### PR DESCRIPTION
- cache results from speedrun.com so that interrupted scripts don't have to fetch the data all over again
- use a config.json for input parameters instead of user input
- check whether the user has reached the 100h limit, if they have then download the video
- add support for some weird urls we missed, and exponetial backoff on 500 errors
- add options for the output video folder (so people can download them to an external drive) and also add an option in the config for whether to download videos